### PR TITLE
Support netns-specific /etc/ config files via /etc/netns

### DIFF
--- a/nsdo.c
+++ b/nsdo.c
@@ -224,7 +224,7 @@ static int bind_mount_file(const char *fn, const struct stat *fstat, int flags, 
 }
 
 /* Bind mount every file in /etc/netns/<ns> to equivalent in /etc. */
-int bind_mount_etc(char *ns) {
+static int bind_mount_etc(char *ns) {
     char bind_path[PATH_MAX + 1];
     DIR *dir;
 

--- a/nsdo.c
+++ b/nsdo.c
@@ -260,7 +260,11 @@ static int bind_mount_etc(char *ns) {
         free(bind_path);
         return 1;
     }
-    closedir(dir);
+
+    if (closedir(dir) == -1) {
+        perror(PROGRAM ": closedir");
+        goto error;
+    }
 
     /* Set up separate mount namespace. */
     if (unshare(CLONE_NEWNS) == -1) {


### PR DESCRIPTION
Based heavily on some fine work contributed by Brian Doherty, but I want to look into alternatives before merging.

There's a good chance I'm being too picky, but doing a bind-mount for every single file in `/etc/netns/X/` for _every single process_ launched in a namespace feels dirty personally, mainly because I want this to be a lightweight tool.

Some brief testing has revealed a practical problem with it, too: files in `/etc/` that are symlinks, namely `/etc/resolv.conf`. On my machine, `/etc/resolv.conf` is a symlink to `/run/resolvconf/resolv.conf`, so `/etc/netns/X/resolv.conf` ends up getting bind-mounted to `/run/resolvconf/resolv.conf`. Then, when I restart NetworkManager (for example) and `/etc/resolvconf/update.d/libc` calls the syscall `rename("/run/resolvconf/resolv.conf_new.1234", "/run/resolvconf/resolv.conf")`, this kills the bind mount, making `/etc/resolv.conf` in the namespace contain the old stuff. For example, this means if I change wifi networks while running a browser in nsdo, I'd need to restart my browser to get the netns-specific resolv.conf in place again.