### PR TITLE
Setting PATH in the openvpn-ns script

### DIFF
--- a/openvpn/openvpn-ns
+++ b/openvpn/openvpn-ns
@@ -1,6 +1,8 @@
 #!/bin/bash
 # based heavily on http://naju.se/articles/openvpn-netns
 
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
 [[ $EUID -ne 0 ]] && {
     printf "%s: this program requires root privileges. try again with \`sudo'?\n" "$0" >&2
     exit 1


### PR DESCRIPTION
This patch sets PATH in the openvpn-ns script to enable the script to run when launched by systemd and no PATH is being set normally.
Alternatively, could just use the full paths for each program (`ip` in particular), but this change is the smallest that works.